### PR TITLE
Fixed the code in __main__.py to prevent TypeError

### DIFF
--- a/quaker_db/__main__.py
+++ b/quaker_db/__main__.py
@@ -151,6 +151,7 @@ def main():
                 args[k] = v
 
     client = Client()
+    kwargs.pop('argfile', None)
     result = client.execute(**args)
 
     print(result)

--- a/quaker_db/__main__.py
+++ b/quaker_db/__main__.py
@@ -151,7 +151,7 @@ def main():
                 args[k] = v
 
     client = Client()
-    kwargs.pop('argfile', None)
+    args.pop('argfile', None)
     result = client.execute(**args)
 
     print(result)


### PR DESCRIPTION
    This pull request fixes a bug in __main__.py where the argfile key was being passed to Client.execute(), causing a TypeError.

Only change:

- Popping 'argfile' from args before calling client.execute(**args) to prevent it from being passed as an unexpected keyword argument.

    This change ensures that Client.execute() only receives valid arguments and prevents runtime errors when argfile is present.